### PR TITLE
Update FWHexView.MappedView.pas

### DIFF
--- a/src/FWHexView.MappedView.pas
+++ b/src/FWHexView.MappedView.pas
@@ -4143,7 +4143,7 @@ end;
 
 procedure TCustomMappedHexView.DoBeforePostPaint(const ADiapason: TVisibleRowDiapason);
 var
-  RegAddress, RegSize: Integer;
+  RegAddress, RegSize: Int64;
   Region: TRegion;
 begin
   RegAddress := RawData.RowToAddress(ADiapason.StartRow, 0);


### PR DESCRIPTION
When scrolling large files, a Range Check error occurs due to the Integer type for RegAddress and RegSize in the procedure TCustomMappedHexView.DoBeforePostPaint(const ADiapason: TVisibleRowDiapason);